### PR TITLE
feat: vNext migration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lingodotdev (0.1.0)
+    lingodotdev (0.2.0)
       json (~> 2.0)
       nokogiri (~> 1.0)
 
@@ -18,6 +18,10 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.15.2)
+    mini_portile2 (2.8.9)
+    nokogiri (1.18.10)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     nokogiri (1.18.10-arm64-darwin)
       racc (~> 1.4)
     pp (0.6.3)
@@ -52,6 +56,7 @@ GEM
 
 PLATFORMS
   arm64-darwin
+  x86_64-linux
 
 DEPENDENCIES
   dotenv (~> 3.0)

--- a/README.md
+++ b/README.md
@@ -61,15 +61,6 @@ result = engine.localize_text(
   source_locale: 'en'
 )
 # => "Hola mundo"
-
-# Fast mode for quicker results
-result = engine.localize_text(
-  'Hello world',
-  target_locale: 'de',
-  source_locale: 'en',
-  fast: true
-)
-# => "Hallo Welt"
 ```
 
 ### Object localization
@@ -285,7 +276,7 @@ The SDK can be configured when creating an engine instance:
 ```ruby
 engine = LingoDotDev::Engine.new(
   api_key: 'your-api-key',          # Required: Your Lingo.dev API key
-  engine_id: 'your-engine-id',      # Required: Your engine ID
+  engine_id: 'your-engine-id',      # Optional: Your engine ID
   api_url: 'https://api.lingo.dev', # Optional: API endpoint URL
   batch_size: 25,                    # Optional: Max items per batch (1-250)
   ideal_batch_item_size: 250         # Optional: Target word count per batch (1-2500)
@@ -306,7 +297,7 @@ end
 | Option                  | Type    | Default                    | Description                               |
 | ----------------------- | ------- | -------------------------- | ----------------------------------------- |
 | `api_key`               | String  | Required                   | Your Lingo.dev API key                    |
-| `engine_id`             | String  | Required                   | Your engine ID for localization processing|
+| `engine_id`             | String  | `nil`                      | Your engine ID for localization processing|
 | `api_url`               | String  | `https://api.lingo.dev`    | API endpoint URL                          |
 | `batch_size`            | Integer | `25`                       | Maximum items per batch (1-250)           |
 | `ideal_batch_item_size` | Integer | `250`                      | Target word count per batch item (1-2500) |
@@ -315,7 +306,7 @@ end
 
 ### Instance methods
 
-#### `localize_text(text, target_locale:, source_locale:, fast: nil, reference: nil, on_progress: nil, concurrent: false, &block)`
+#### `localize_text(text, target_locale:, source_locale:, reference: nil, on_progress: nil, concurrent: false, &block)`
 
 Localizes a string to the target locale.
 
@@ -323,28 +314,27 @@ Localizes a string to the target locale.
   - `text` (String): Text to localize
   - `target_locale` (String): Target locale code (e.g., 'es', 'fr', 'ja')
   - `source_locale` (String): Source locale code (e.g., 'en')
-  - `fast` (Boolean, optional): Enable fast mode
   - `reference` (Hash, optional): Additional context for translation
   - `on_progress` (Proc, optional): Progress callback
   - `concurrent` (Boolean): Enable concurrent processing
   - `&block`: Alternative progress callback
 - **Returns:** Localized string
 
-#### `localize_object(obj, target_locale:, source_locale:, fast: nil, reference: nil, on_progress: nil, concurrent: false, &block)`
+#### `localize_object(obj, target_locale:, source_locale:, reference: nil, on_progress: nil, concurrent: false, &block)`
 
 Localizes all string values in a Hash.
 
 - **Parameters:** Same as `localize_text`, with `obj` (Hash) instead of `text`
 - **Returns:** Localized Hash
 
-#### `localize_chat(chat, target_locale:, source_locale:, fast: nil, reference: nil, on_progress: nil, concurrent: false, &block)`
+#### `localize_chat(chat, target_locale:, source_locale:, reference: nil, on_progress: nil, concurrent: false, &block)`
 
 Localizes chat messages. Each message must have `:name` and `:text` keys.
 
 - **Parameters:** Same as `localize_text`, with `chat` (Array) instead of `text`
 - **Returns:** Array of localized chat messages
 
-#### `localize_html(html, target_locale:, source_locale:, fast: nil, reference: nil, on_progress: nil, concurrent: false, &block)`
+#### `localize_html(html, target_locale:, source_locale:, reference: nil, on_progress: nil, concurrent: false, &block)`
 
 Localizes an HTML document while preserving structure and formatting. Handles both text content and localizable attributes (alt, title, placeholder, meta content).
 
@@ -352,14 +342,13 @@ Localizes an HTML document while preserving structure and formatting. Handles bo
   - `html` (String): HTML document string to localize
   - `target_locale` (String): Target locale code (e.g., 'es', 'fr', 'ja')
   - `source_locale` (String): Source locale code (e.g., 'en')
-  - `fast` (Boolean, optional): Enable fast mode
   - `reference` (Hash, optional): Additional context for translation
   - `on_progress` (Proc, optional): Progress callback
   - `concurrent` (Boolean): Enable concurrent processing
   - `&block`: Alternative progress callback
 - **Returns:** Localized HTML document string with updated `lang` attribute
 
-#### `batch_localize_text(text, target_locales:, source_locale:, fast: nil, reference: nil, concurrent: false)`
+#### `batch_localize_text(text, target_locales:, source_locale:, reference: nil, concurrent: false)`
 
 Localizes text to multiple target locales.
 
@@ -369,7 +358,7 @@ Localizes text to multiple target locales.
   - Other parameters same as `localize_text`
 - **Returns:** Array of localized strings
 
-#### `batch_localize_objects(objects, target_locale:, source_locale:, fast: nil, reference: nil, concurrent: false)`
+#### `batch_localize_objects(objects, target_locale:, source_locale:, reference: nil, concurrent: false)`
 
 Localizes multiple objects to the same target locale.
 
@@ -395,7 +384,7 @@ Returns information about the authenticated user.
 
 ### Class methods
 
-#### `Engine.quick_translate(content, api_key:, engine_id:, target_locale:, source_locale:, fast: true, api_url: 'https://api.lingo.dev')`
+#### `Engine.quick_translate(content, api_key:, engine_id: nil, target_locale:, source_locale:, api_url: 'https://api.lingo.dev')`
 
 One-off translation without managing engine lifecycle.
 
@@ -404,7 +393,7 @@ One-off translation without managing engine lifecycle.
   - Other parameters as in instance methods
 - **Returns:** Translated String or Hash
 
-#### `Engine.quick_batch_translate(content, api_key:, engine_id:, target_locales:, source_locale:, fast: true, api_url: 'https://api.lingo.dev')`
+#### `Engine.quick_batch_translate(content, api_key:, engine_id: nil, target_locales:, source_locale:, api_url: 'https://api.lingo.dev')`
 
 One-off batch translation to multiple locales.
 
@@ -420,7 +409,7 @@ The SDK defines custom exception classes for different error scenarios:
 
 ```ruby
 begin
-  engine = LingoDotDev::Engine.new(api_key: 'your-api-key', engine_id: 'your-engine-id')
+  engine = LingoDotDev::Engine.new(api_key: 'your-api-key')
   result = engine.localize_text('Hello', target_locale: 'es', source_locale: 'en')
 rescue LingoDotDev::ValidationError => e
   # Invalid input or configuration

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ gem install lingodotdev
 require 'lingodotdev'
 
 # Create an engine instance
-engine = LingoDotDev::Engine.new(api_key: 'your-api-key')
+engine = LingoDotDev::Engine.new(api_key: 'your-api-key', engine_id: 'your-engine-id')
 
 # Localize text
-result = engine.localize_text('Hello world', target_locale: 'es')
+result = engine.localize_text('Hello world', target_locale: 'es', source_locale: 'en')
 puts result # => "Hola mundo"
 ```
 
@@ -53,26 +53,20 @@ puts result # => "Hola mundo"
 Localize a simple string to a target locale:
 
 ```ruby
-engine = LingoDotDev::Engine.new(api_key: 'your-api-key')
+engine = LingoDotDev::Engine.new(api_key: 'your-api-key', engine_id: 'your-engine-id')
 
 result = engine.localize_text(
   'Hello world',
-  target_locale: 'es'
-)
-# => "Hola mundo"
-
-# With source locale specified
-result = engine.localize_text(
-  'Hello world',
-  target_locale: 'fr',
+  target_locale: 'es',
   source_locale: 'en'
 )
-# => "Bonjour le monde"
+# => "Hola mundo"
 
 # Fast mode for quicker results
 result = engine.localize_text(
   'Hello world',
   target_locale: 'de',
+  source_locale: 'en',
   fast: true
 )
 # => "Hallo Welt"
@@ -89,7 +83,7 @@ data = {
   message: 'Welcome to our app'
 }
 
-result = engine.localize_object(data, target_locale: 'es')
+result = engine.localize_object(data, target_locale: 'es', source_locale: 'en')
 # => {
 #   greeting: "Hola",
 #   farewell: "Adiós",
@@ -108,7 +102,7 @@ chat = [
   { name: 'user', text: 'I need some information.' }
 ]
 
-result = engine.localize_chat(chat, target_locale: 'ja')
+result = engine.localize_chat(chat, target_locale: 'ja', source_locale: 'en')
 # => [
 #   { name: 'user', text: 'こんにちは！' },
 #   { name: 'assistant', text: 'こんにちは！どのようにお手伝いできますか？' },
@@ -136,7 +130,7 @@ html = <<~HTML
   </html>
 HTML
 
-result = engine.localize_html(html, target_locale: 'es')
+result = engine.localize_html(html, target_locale: 'es', source_locale: 'en')
 # => HTML with localized text content and attributes, lang="es" attribute updated
 ```
 
@@ -156,7 +150,8 @@ Localize the same content to multiple target locales:
 # Batch localize text
 results = engine.batch_localize_text(
   'Hello world',
-  target_locales: ['es', 'fr', 'de']
+  target_locales: ['es', 'fr', 'de'],
+  source_locale: 'en'
 )
 # => ["Hola mundo", "Bonjour le monde", "Hallo Welt"]
 
@@ -164,6 +159,7 @@ results = engine.batch_localize_text(
 results = engine.batch_localize_text(
   'Hello world',
   target_locales: ['es', 'fr', 'de', 'ja'],
+  source_locale: 'en',
   concurrent: true
 )
 ```
@@ -182,6 +178,7 @@ objects = [
 results = engine.batch_localize_objects(
   objects,
   target_locale: 'es',
+  source_locale: 'en',
   concurrent: true
 )
 # => [
@@ -198,9 +195,6 @@ Automatically detect the locale of a given text:
 ```ruby
 locale = engine.recognize_locale('Bonjour le monde')
 # => "fr"
-
-locale = engine.recognize_locale('こんにちは世界')
-# => "ja"
 ```
 
 ### Progress tracking
@@ -209,7 +203,7 @@ Monitor localization progress with callbacks:
 
 ```ruby
 # Using a block
-result = engine.localize_text('Hello world', target_locale: 'es') do |progress|
+result = engine.localize_text('Hello world', target_locale: 'es', source_locale: 'en') do |progress|
   puts "Progress: #{progress}%"
 end
 
@@ -218,6 +212,7 @@ callback = proc { |progress| puts "Progress: #{progress}%" }
 result = engine.localize_text(
   'Hello world',
   target_locale: 'es',
+  source_locale: 'en',
   on_progress: callback
 )
 ```
@@ -236,6 +231,7 @@ reference = {
 result = engine.localize_text(
   'Hello',
   target_locale: 'ja',
+  source_locale: 'en',
   reference: reference
 )
 ```
@@ -249,21 +245,27 @@ For one-off translations without managing engine instances:
 result = LingoDotDev::Engine.quick_translate(
   'Hello world',
   api_key: 'your-api-key',
-  target_locale: 'es'
+  engine_id: 'your-engine-id',
+  target_locale: 'es',
+  source_locale: 'en'
 )
 
 # Quick translate a hash
 result = LingoDotDev::Engine.quick_translate(
   { greeting: 'Hello', farewell: 'Goodbye' },
   api_key: 'your-api-key',
-  target_locale: 'fr'
+  engine_id: 'your-engine-id',
+  target_locale: 'fr',
+  source_locale: 'en'
 )
 
 # Quick batch translate to multiple locales
 results = LingoDotDev::Engine.quick_batch_translate(
   'Hello',
   api_key: 'your-api-key',
-  target_locales: ['es', 'fr', 'de']
+  engine_id: 'your-engine-id',
+  target_locales: ['es', 'fr', 'de'],
+  source_locale: 'en'
 )
 ```
 
@@ -283,7 +285,8 @@ The SDK can be configured when creating an engine instance:
 ```ruby
 engine = LingoDotDev::Engine.new(
   api_key: 'your-api-key',          # Required: Your Lingo.dev API key
-  api_url: 'https://engine.lingo.dev', # Optional: API endpoint URL
+  engine_id: 'your-engine-id',      # Required: Your engine ID
+  api_url: 'https://api.lingo.dev', # Optional: API endpoint URL
   batch_size: 25,                    # Optional: Max items per batch (1-250)
   ideal_batch_item_size: 250         # Optional: Target word count per batch (1-2500)
 )
@@ -292,7 +295,7 @@ engine = LingoDotDev::Engine.new(
 You can also configure using a block:
 
 ```ruby
-engine = LingoDotDev::Engine.new(api_key: 'your-api-key') do |config|
+engine = LingoDotDev::Engine.new(api_key: 'your-api-key', engine_id: 'your-engine-id') do |config|
   config.batch_size = 50
   config.ideal_batch_item_size = 500
 end
@@ -303,7 +306,8 @@ end
 | Option                  | Type    | Default                    | Description                               |
 | ----------------------- | ------- | -------------------------- | ----------------------------------------- |
 | `api_key`               | String  | Required                   | Your Lingo.dev API key                    |
-| `api_url`               | String  | `https://engine.lingo.dev` | API endpoint URL                          |
+| `engine_id`             | String  | Required                   | Your engine ID for localization processing|
+| `api_url`               | String  | `https://api.lingo.dev`    | API endpoint URL                          |
 | `batch_size`            | Integer | `25`                       | Maximum items per batch (1-250)           |
 | `ideal_batch_item_size` | Integer | `250`                      | Target word count per batch item (1-2500) |
 
@@ -311,14 +315,14 @@ end
 
 ### Instance methods
 
-#### `localize_text(text, target_locale:, source_locale: nil, fast: nil, reference: nil, on_progress: nil, concurrent: false, &block)`
+#### `localize_text(text, target_locale:, source_locale:, fast: nil, reference: nil, on_progress: nil, concurrent: false, &block)`
 
 Localizes a string to the target locale.
 
 - **Parameters:**
   - `text` (String): Text to localize
   - `target_locale` (String): Target locale code (e.g., 'es', 'fr', 'ja')
-  - `source_locale` (String, optional): Source locale code
+  - `source_locale` (String): Source locale code (e.g., 'en')
   - `fast` (Boolean, optional): Enable fast mode
   - `reference` (Hash, optional): Additional context for translation
   - `on_progress` (Proc, optional): Progress callback
@@ -326,28 +330,28 @@ Localizes a string to the target locale.
   - `&block`: Alternative progress callback
 - **Returns:** Localized string
 
-#### `localize_object(obj, target_locale:, source_locale: nil, fast: nil, reference: nil, on_progress: nil, concurrent: false, &block)`
+#### `localize_object(obj, target_locale:, source_locale:, fast: nil, reference: nil, on_progress: nil, concurrent: false, &block)`
 
 Localizes all string values in a Hash.
 
 - **Parameters:** Same as `localize_text`, with `obj` (Hash) instead of `text`
 - **Returns:** Localized Hash
 
-#### `localize_chat(chat, target_locale:, source_locale: nil, fast: nil, reference: nil, on_progress: nil, concurrent: false, &block)`
+#### `localize_chat(chat, target_locale:, source_locale:, fast: nil, reference: nil, on_progress: nil, concurrent: false, &block)`
 
 Localizes chat messages. Each message must have `:name` and `:text` keys.
 
 - **Parameters:** Same as `localize_text`, with `chat` (Array) instead of `text`
 - **Returns:** Array of localized chat messages
 
-#### `localize_html(html, target_locale:, source_locale: nil, fast: nil, reference: nil, on_progress: nil, concurrent: false, &block)`
+#### `localize_html(html, target_locale:, source_locale:, fast: nil, reference: nil, on_progress: nil, concurrent: false, &block)`
 
 Localizes an HTML document while preserving structure and formatting. Handles both text content and localizable attributes (alt, title, placeholder, meta content).
 
 - **Parameters:**
   - `html` (String): HTML document string to localize
   - `target_locale` (String): Target locale code (e.g., 'es', 'fr', 'ja')
-  - `source_locale` (String, optional): Source locale code
+  - `source_locale` (String): Source locale code (e.g., 'en')
   - `fast` (Boolean, optional): Enable fast mode
   - `reference` (Hash, optional): Additional context for translation
   - `on_progress` (Proc, optional): Progress callback
@@ -355,7 +359,7 @@ Localizes an HTML document while preserving structure and formatting. Handles bo
   - `&block`: Alternative progress callback
 - **Returns:** Localized HTML document string with updated `lang` attribute
 
-#### `batch_localize_text(text, target_locales:, source_locale: nil, fast: nil, reference: nil, concurrent: false)`
+#### `batch_localize_text(text, target_locales:, source_locale:, fast: nil, reference: nil, concurrent: false)`
 
 Localizes text to multiple target locales.
 
@@ -365,7 +369,7 @@ Localizes text to multiple target locales.
   - Other parameters same as `localize_text`
 - **Returns:** Array of localized strings
 
-#### `batch_localize_objects(objects, target_locale:, source_locale: nil, fast: nil, reference: nil, concurrent: false)`
+#### `batch_localize_objects(objects, target_locale:, source_locale:, fast: nil, reference: nil, concurrent: false)`
 
 Localizes multiple objects to the same target locale.
 
@@ -391,7 +395,7 @@ Returns information about the authenticated user.
 
 ### Class methods
 
-#### `Engine.quick_translate(content, api_key:, target_locale:, source_locale: nil, fast: true, api_url: 'https://engine.lingo.dev')`
+#### `Engine.quick_translate(content, api_key:, engine_id:, target_locale:, source_locale:, fast: true, api_url: 'https://api.lingo.dev')`
 
 One-off translation without managing engine lifecycle.
 
@@ -400,7 +404,7 @@ One-off translation without managing engine lifecycle.
   - Other parameters as in instance methods
 - **Returns:** Translated String or Hash
 
-#### `Engine.quick_batch_translate(content, api_key:, target_locales:, source_locale: nil, fast: true, api_url: 'https://engine.lingo.dev')`
+#### `Engine.quick_batch_translate(content, api_key:, engine_id:, target_locales:, source_locale:, fast: true, api_url: 'https://api.lingo.dev')`
 
 One-off batch translation to multiple locales.
 
@@ -416,8 +420,8 @@ The SDK defines custom exception classes for different error scenarios:
 
 ```ruby
 begin
-  engine = LingoDotDev::Engine.new(api_key: 'your-api-key')
-  result = engine.localize_text('Hello', target_locale: 'es')
+  engine = LingoDotDev::Engine.new(api_key: 'your-api-key', engine_id: 'your-engine-id')
+  result = engine.localize_text('Hello', target_locale: 'es', source_locale: 'en')
 rescue LingoDotDev::ValidationError => e
   # Invalid input or configuration
   puts "Validation error: #{e.message}"

--- a/examples/ruby-on-rails/app/controllers/translate_controller.rb
+++ b/examples/ruby-on-rails/app/controllers/translate_controller.rb
@@ -5,9 +5,10 @@ require 'lingodotdev'
 class TranslateController < ApplicationController
   def translate
     api_key = ENV['LINGODOTDEV_API_KEY'] || 'your-api-key-here'
+    engine_id = ENV['LINGODOTDEV_ENGINE_ID'] || 'your-engine-id-here'
 
-    engine = LingoDotDev::Engine.new(api_key: api_key)
-    translated = engine.localize_text('Hello world', target_locale: 'es')
+    engine = LingoDotDev::Engine.new(api_key: api_key, engine_id: engine_id)
+    translated = engine.localize_text('Hello world', target_locale: 'es', source_locale: 'en')
 
     render json: {
       original: 'Hello world',

--- a/lib/lingodotdev.rb
+++ b/lib/lingodotdev.rb
@@ -54,7 +54,7 @@ end
 # localization with batch operations, progress tracking, and concurrent processing.
 #
 # @example Basic usage
-#   engine = LingoDotDev::Engine.new(api_key: 'your-api-key', engine_id: 'your-engine-id')
+#   engine = LingoDotDev::Engine.new(api_key: 'your-api-key')
 #   result = engine.localize_text('Hello world', target_locale: 'es', source_locale: 'en')
 #   puts result # => "Hola mundo"
 #
@@ -88,7 +88,7 @@ module LingoDotDev
     # @return [String] the API endpoint URL
     attr_accessor :api_url
 
-    # @return [String] the engine ID for localization processing
+    # @return [String, nil] the engine ID for localization processing
     attr_accessor :engine_id
 
     # @return [Integer] maximum number of items per batch (1-250)
@@ -100,13 +100,13 @@ module LingoDotDev
     # Creates a new Configuration instance.
     #
     # @param api_key [String] your Lingo.dev API key (required)
-    # @param engine_id [String] the engine ID for localization processing (required)
+    # @param engine_id [String, nil] the engine ID for localization processing (optional)
     # @param api_url [String] the API endpoint URL (default: 'https://api.lingo.dev')
     # @param batch_size [Integer] maximum items per batch, 1-250 (default: 25)
     # @param ideal_batch_item_size [Integer] target word count per batch item, 1-2500 (default: 250)
     #
     # @raise [ValidationError] if any parameter is invalid
-    def initialize(api_key:, engine_id:, api_url: 'https://api.lingo.dev', batch_size: 25, ideal_batch_item_size: 250)
+    def initialize(api_key:, engine_id: nil, api_url: 'https://api.lingo.dev', batch_size: 25, ideal_batch_item_size: 250)
       @api_key = api_key
       @engine_id = engine_id
       @api_url = api_url
@@ -119,7 +119,6 @@ module LingoDotDev
 
     def validate!
       raise ValidationError, 'API key is required' if api_key.nil? || api_key.empty?
-      raise ValidationError, 'Engine ID is required' if engine_id.nil? || engine_id.empty?
       raise ValidationError, 'API URL must be a valid HTTP/HTTPS URL' unless api_url =~ /\Ahttps?:\/\/.+/
       raise ValidationError, 'Batch size must be between 1 and 250' unless batch_size.is_a?(Integer) && batch_size.between?(1, 250)
       raise ValidationError, 'Ideal batch item size must be between 1 and 2500' unless ideal_batch_item_size.is_a?(Integer) && ideal_batch_item_size.between?(1, 2500)
@@ -151,7 +150,7 @@ module LingoDotDev
     # Creates a new Engine instance.
     #
     # @param api_key [String] your Lingo.dev API key (required)
-    # @param engine_id [String] the engine ID for localization processing (required)
+    # @param engine_id [String, nil] the engine ID for localization processing (optional)
     # @param api_url [String] the API endpoint URL (default: 'https://api.lingo.dev')
     # @param batch_size [Integer] maximum items per batch, 1-250 (default: 25)
     # @param ideal_batch_item_size [Integer] target word count per batch item, 1-2500 (default: 250)
@@ -172,7 +171,7 @@ module LingoDotDev
     #     config.batch_size = 50
     #     config.ideal_batch_item_size = 500
     #   end
-    def initialize(api_key:, engine_id:, api_url: 'https://api.lingo.dev', batch_size: 25, ideal_batch_item_size: 250)
+    def initialize(api_key:, engine_id: nil, api_url: 'https://api.lingo.dev', batch_size: 25, ideal_batch_item_size: 250)
       @config = Configuration.new(
         api_key: api_key,
         engine_id: engine_id,
@@ -685,7 +684,7 @@ module LingoDotDev
     #
     # @param content [String, Hash] the content to translate (String for text, Hash for object)
     # @param api_key [String] your Lingo.dev API key
-    # @param engine_id [String] the engine ID for localization processing
+    # @param engine_id [String, nil] the engine ID for localization processing (optional)
     # @param target_locale [String] the target locale code (e.g., 'es', 'fr', 'ja')
     # @param source_locale [String] the source locale code (e.g., 'en')
     # @param fast [Boolean] enable fast mode for quicker results (default: true)
@@ -709,7 +708,7 @@ module LingoDotDev
     #     source_locale: 'en'
     #   )
     #   # => { greeting: "Bonjour", farewell: "Au revoir" }
-    def self.quick_translate(content, api_key:, engine_id:, target_locale:, source_locale:, fast: true, api_url: 'https://api.lingo.dev')
+    def self.quick_translate(content, api_key:, engine_id: nil, target_locale:, source_locale:, fast: true, api_url: 'https://api.lingo.dev')
       engine = new(api_key: api_key, engine_id: engine_id, api_url: api_url)
       case content
       when String
@@ -739,7 +738,7 @@ module LingoDotDev
     #
     # @param content [String, Hash] the content to translate (String for text, Hash for object)
     # @param api_key [String] your Lingo.dev API key
-    # @param engine_id [String] the engine ID for localization processing
+    # @param engine_id [String, nil] the engine ID for localization processing (optional)
     # @param target_locales [Array<String>] array of target locale codes
     # @param source_locale [String] the source locale code (e.g., 'en')
     # @param fast [Boolean] enable fast mode for quicker results (default: true)
@@ -764,12 +763,11 @@ module LingoDotDev
     #   results = LingoDotDev::Engine.quick_batch_translate(
     #     { greeting: 'Hello' },
     #     api_key: 'your-api-key',
-    #     engine_id: 'your-engine-id',
     #     target_locales: ['es', 'fr'],
     #     source_locale: 'en'
     #   )
     #   # => [{ greeting: "Hola" }, { greeting: "Bonjour" }]
-    def self.quick_batch_translate(content, api_key:, engine_id:, target_locales:, source_locale:, fast: true, api_url: 'https://api.lingo.dev')
+    def self.quick_batch_translate(content, api_key:, engine_id: nil, target_locales:, source_locale:, fast: true, api_url: 'https://api.lingo.dev')
       engine = new(api_key: api_key, engine_id: engine_id, api_url: api_url)
       case content
       when String
@@ -865,6 +863,8 @@ module LingoDotDev
         sessionId: @session_id
       }
 
+      request_body[:engineId] = config.engine_id unless config.engine_id.nil?
+
       if reference && !reference.empty?
         raise ValidationError, 'Reference must be a Hash' unless reference.is_a?(Hash)
         request_body[:reference] = reference
@@ -874,7 +874,7 @@ module LingoDotDev
 
       begin
         response = make_request(
-          "#{config.api_url}/process/#{config.engine_id}/localize",
+          "#{config.api_url}/process/localize",
           json: request_body
         )
 

--- a/lib/lingodotdev.rb
+++ b/lib/lingodotdev.rb
@@ -54,8 +54,8 @@ end
 # localization with batch operations, progress tracking, and concurrent processing.
 #
 # @example Basic usage
-#   engine = LingoDotDev::Engine.new(api_key: 'your-api-key')
-#   result = engine.localize_text('Hello world', target_locale: 'es')
+#   engine = LingoDotDev::Engine.new(api_key: 'your-api-key', engine_id: 'your-engine-id')
+#   result = engine.localize_text('Hello world', target_locale: 'es', source_locale: 'en')
 #   puts result # => "Hola mundo"
 #
 # @see Engine
@@ -88,6 +88,9 @@ module LingoDotDev
     # @return [String] the API endpoint URL
     attr_accessor :api_url
 
+    # @return [String] the engine ID for localization processing
+    attr_accessor :engine_id
+
     # @return [Integer] maximum number of items per batch (1-250)
     attr_accessor :batch_size
 
@@ -97,13 +100,15 @@ module LingoDotDev
     # Creates a new Configuration instance.
     #
     # @param api_key [String] your Lingo.dev API key (required)
-    # @param api_url [String] the API endpoint URL (default: 'https://engine.lingo.dev')
+    # @param engine_id [String] the engine ID for localization processing (required)
+    # @param api_url [String] the API endpoint URL (default: 'https://api.lingo.dev')
     # @param batch_size [Integer] maximum items per batch, 1-250 (default: 25)
     # @param ideal_batch_item_size [Integer] target word count per batch item, 1-2500 (default: 250)
     #
     # @raise [ValidationError] if any parameter is invalid
-    def initialize(api_key:, api_url: 'https://engine.lingo.dev', batch_size: 25, ideal_batch_item_size: 250)
+    def initialize(api_key:, engine_id:, api_url: 'https://api.lingo.dev', batch_size: 25, ideal_batch_item_size: 250)
       @api_key = api_key
+      @engine_id = engine_id
       @api_url = api_url
       @batch_size = batch_size
       @ideal_batch_item_size = ideal_batch_item_size
@@ -114,6 +119,7 @@ module LingoDotDev
 
     def validate!
       raise ValidationError, 'API key is required' if api_key.nil? || api_key.empty?
+      raise ValidationError, 'Engine ID is required' if engine_id.nil? || engine_id.empty?
       raise ValidationError, 'API URL must be a valid HTTP/HTTPS URL' unless api_url =~ /\Ahttps?:\/\/.+/
       raise ValidationError, 'Batch size must be between 1 and 250' unless batch_size.is_a?(Integer) && batch_size.between?(1, 250)
       raise ValidationError, 'Ideal batch item size must be between 1 and 2500' unless ideal_batch_item_size.is_a?(Integer) && ideal_batch_item_size.between?(1, 2500)
@@ -126,17 +132,17 @@ module LingoDotDev
   # with support for batch operations, progress tracking, and concurrent processing.
   #
   # @example Basic text localization
-  #   engine = LingoDotDev::Engine.new(api_key: 'your-api-key')
-  #   result = engine.localize_text('Hello', target_locale: 'es')
+  #   engine = LingoDotDev::Engine.new(api_key: 'your-api-key', engine_id: 'your-engine-id')
+  #   result = engine.localize_text('Hello', target_locale: 'es', source_locale: 'en')
   #   # => "Hola"
   #
   # @example Object localization
   #   data = { greeting: 'Hello', farewell: 'Goodbye' }
-  #   result = engine.localize_object(data, target_locale: 'fr')
+  #   result = engine.localize_object(data, target_locale: 'fr', source_locale: 'en')
   #   # => { greeting: "Bonjour", farewell: "Au revoir" }
   #
   # @example Batch localization
-  #   results = engine.batch_localize_text('Hello', target_locales: ['es', 'fr', 'de'])
+  #   results = engine.batch_localize_text('Hello', target_locales: ['es', 'fr', 'de'], source_locale: 'en')
   #   # => ["Hola", "Bonjour", "Hallo"]
   class Engine
     # @return [Configuration] the engine's configuration
@@ -145,7 +151,8 @@ module LingoDotDev
     # Creates a new Engine instance.
     #
     # @param api_key [String] your Lingo.dev API key (required)
-    # @param api_url [String] the API endpoint URL (default: 'https://engine.lingo.dev')
+    # @param engine_id [String] the engine ID for localization processing (required)
+    # @param api_url [String] the API endpoint URL (default: 'https://api.lingo.dev')
     # @param batch_size [Integer] maximum items per batch, 1-250 (default: 25)
     # @param ideal_batch_item_size [Integer] target word count per batch item, 1-2500 (default: 250)
     #
@@ -155,23 +162,25 @@ module LingoDotDev
     # @raise [ValidationError] if any parameter is invalid
     #
     # @example Basic initialization
-    #   engine = LingoDotDev::Engine.new(api_key: 'your-api-key')
+    #   engine = LingoDotDev::Engine.new(api_key: 'your-api-key', engine_id: 'your-engine-id')
     #
     # @example With custom configuration
-    #   engine = LingoDotDev::Engine.new(api_key: 'your-api-key', batch_size: 50)
+    #   engine = LingoDotDev::Engine.new(api_key: 'your-api-key', engine_id: 'your-engine-id', batch_size: 50)
     #
     # @example With block configuration
-    #   engine = LingoDotDev::Engine.new(api_key: 'your-api-key') do |config|
+    #   engine = LingoDotDev::Engine.new(api_key: 'your-api-key', engine_id: 'your-engine-id') do |config|
     #     config.batch_size = 50
     #     config.ideal_batch_item_size = 500
     #   end
-    def initialize(api_key:, api_url: 'https://engine.lingo.dev', batch_size: 25, ideal_batch_item_size: 250)
+    def initialize(api_key:, engine_id:, api_url: 'https://api.lingo.dev', batch_size: 25, ideal_batch_item_size: 250)
       @config = Configuration.new(
         api_key: api_key,
+        engine_id: engine_id,
         api_url: api_url,
         batch_size: batch_size,
         ideal_batch_item_size: ideal_batch_item_size
       )
+      @session_id = SecureRandom.hex(16)
       yield @config if block_given?
       @config.send(:validate!)
     end
@@ -180,7 +189,7 @@ module LingoDotDev
     #
     # @param text [String] the text to localize
     # @param target_locale [String] the target locale code (e.g., 'es', 'fr', 'ja')
-    # @param source_locale [String, nil] the source locale code (optional, auto-detected if not provided)
+    # @param source_locale [String] the source locale code (e.g., 'en')
     # @param fast [Boolean, nil] enable fast mode for quicker results (optional)
     # @param reference [Hash, nil] additional context for translation (optional)
     # @param on_progress [Proc, nil] callback for progress updates (optional)
@@ -195,18 +204,14 @@ module LingoDotDev
     # @raise [APIError] if the API request fails
     #
     # @example Basic usage
-    #   result = engine.localize_text('Hello', target_locale: 'es')
+    #   result = engine.localize_text('Hello', target_locale: 'es', source_locale: 'en')
     #   # => "Hola"
     #
-    # @example With source locale
-    #   result = engine.localize_text('Hello', target_locale: 'fr', source_locale: 'en')
-    #   # => "Bonjour"
-    #
     # @example With progress tracking
-    #   result = engine.localize_text('Hello', target_locale: 'de') do |progress|
+    #   result = engine.localize_text('Hello', target_locale: 'de', source_locale: 'en') do |progress|
     #     puts "Progress: #{progress}%"
     #   end
-    def localize_text(text, target_locale:, source_locale: nil, fast: nil, reference: nil, on_progress: nil, concurrent: false, &block)
+    def localize_text(text, target_locale:, source_locale:, fast: nil, reference: nil, on_progress: nil, concurrent: false, &block)
       raise ValidationError, 'Target locale is required' if target_locale.nil? || target_locale.empty?
       raise ValidationError, 'Text cannot be nil' if text.nil?
 
@@ -231,7 +236,7 @@ module LingoDotDev
     #
     # @param obj [Hash] the Hash object to localize
     # @param target_locale [String] the target locale code (e.g., 'es', 'fr', 'ja')
-    # @param source_locale [String, nil] the source locale code (optional, auto-detected if not provided)
+    # @param source_locale [String] the source locale code (e.g., 'en')
     # @param fast [Boolean, nil] enable fast mode for quicker results (optional)
     # @param reference [Hash, nil] additional context for translation (optional)
     # @param on_progress [Proc, nil] callback for progress updates (optional)
@@ -247,9 +252,9 @@ module LingoDotDev
     #
     # @example Basic usage
     #   data = { greeting: 'Hello', farewell: 'Goodbye' }
-    #   result = engine.localize_object(data, target_locale: 'es')
+    #   result = engine.localize_object(data, target_locale: 'es', source_locale: 'en')
     #   # => { greeting: "Hola", farewell: "Adiós" }
-    def localize_object(obj, target_locale:, source_locale: nil, fast: nil, reference: nil, on_progress: nil, concurrent: false, &block)
+    def localize_object(obj, target_locale:, source_locale:, fast: nil, reference: nil, on_progress: nil, concurrent: false, &block)
       raise ValidationError, 'Target locale is required' if target_locale.nil? || target_locale.empty?
       raise ValidationError, 'Object cannot be nil' if obj.nil?
       raise ValidationError, 'Object must be a Hash' unless obj.is_a?(Hash)
@@ -277,7 +282,7 @@ module LingoDotDev
     #
     # @param chat [Array<Hash>] array of chat messages, each with :name and :text keys
     # @param target_locale [String] the target locale code (e.g., 'es', 'fr', 'ja')
-    # @param source_locale [String, nil] the source locale code (optional, auto-detected if not provided)
+    # @param source_locale [String] the source locale code (e.g., 'en')
     # @param fast [Boolean, nil] enable fast mode for quicker results (optional)
     # @param reference [Hash, nil] additional context for translation (optional)
     # @param on_progress [Proc, nil] callback for progress updates (optional)
@@ -296,12 +301,12 @@ module LingoDotDev
     #     { name: 'user', text: 'Hello!' },
     #     { name: 'assistant', text: 'Hi there!' }
     #   ]
-    #   result = engine.localize_chat(chat, target_locale: 'ja')
+    #   result = engine.localize_chat(chat, target_locale: 'ja', source_locale: 'en')
     #   # => [
     #   #   { name: 'user', text: 'こんにちは！' },
     #   #   { name: 'assistant', text: 'こんにちは！' }
     #   # ]
-    def localize_chat(chat, target_locale:, source_locale: nil, fast: nil, reference: nil, on_progress: nil, concurrent: false, &block)
+    def localize_chat(chat, target_locale:, source_locale:, fast: nil, reference: nil, on_progress: nil, concurrent: false, &block)
       raise ValidationError, 'Target locale is required' if target_locale.nil? || target_locale.empty?
       raise ValidationError, 'Chat cannot be nil' if chat.nil?
       raise ValidationError, 'Chat must be an Array' unless chat.is_a?(Array)
@@ -335,7 +340,7 @@ module LingoDotDev
     #
     # @param html [String] the HTML document string to be localized
     # @param target_locale [String] the target locale code (e.g., 'es', 'fr', 'ja')
-    # @param source_locale [String, nil] the source locale code (optional, auto-detected if not provided)
+    # @param source_locale [String] the source locale code (e.g., 'en')
     # @param fast [Boolean, nil] enable fast mode for quicker results (optional)
     # @param reference [Hash, nil] additional context for translation (optional)
     # @param on_progress [Proc, nil] callback for progress updates (optional)
@@ -351,9 +356,9 @@ module LingoDotDev
     #
     # @example Basic usage
     #   html = '<html><head><title>Hello</title></head><body><p>World</p></body></html>'
-    #   result = engine.localize_html(html, target_locale: 'es')
+    #   result = engine.localize_html(html, target_locale: 'es', source_locale: 'en')
     #   # => "<html lang=\"es\">..."
-    def localize_html(html, target_locale:, source_locale: nil, fast: nil, reference: nil, on_progress: nil, concurrent: false, &block)
+    def localize_html(html, target_locale:, source_locale:, fast: nil, reference: nil, on_progress: nil, concurrent: false, &block)
       raise ValidationError, 'Target locale is required' if target_locale.nil? || target_locale.empty?
       raise ValidationError, 'HTML cannot be nil' if html.nil?
 
@@ -508,7 +513,7 @@ module LingoDotDev
     #
     # @param text [String] the text to localize
     # @param target_locales [Array<String>] array of target locale codes
-    # @param source_locale [String, nil] the source locale code (optional, auto-detected if not provided)
+    # @param source_locale [String] the source locale code (e.g., 'en')
     # @param fast [Boolean, nil] enable fast mode for quicker results (optional)
     # @param reference [Hash, nil] additional context for translation (optional)
     # @param concurrent [Boolean] enable concurrent processing (default: false)
@@ -519,12 +524,12 @@ module LingoDotDev
     # @raise [APIError] if any API request fails
     #
     # @example Basic usage
-    #   results = engine.batch_localize_text('Hello', target_locales: ['es', 'fr', 'de'])
+    #   results = engine.batch_localize_text('Hello', target_locales: ['es', 'fr', 'de'], source_locale: 'en')
     #   # => ["Hola", "Bonjour", "Hallo"]
     #
     # @example With concurrent processing
-    #   results = engine.batch_localize_text('Hello', target_locales: ['es', 'fr', 'de', 'ja'], concurrent: true)
-    def batch_localize_text(text, target_locales:, source_locale: nil, fast: nil, reference: nil, concurrent: false)
+    #   results = engine.batch_localize_text('Hello', target_locales: ['es', 'fr', 'de', 'ja'], source_locale: 'en', concurrent: true)
+    def batch_localize_text(text, target_locales:, source_locale:, fast: nil, reference: nil, concurrent: false)
       raise ValidationError, 'Text cannot be nil' if text.nil?
       raise ValidationError, 'Target locales must be an Array' unless target_locales.is_a?(Array)
       raise ValidationError, 'Target locales cannot be empty' if target_locales.empty?
@@ -559,7 +564,7 @@ module LingoDotDev
     #
     # @param objects [Array<Hash>] array of Hash objects to localize
     # @param target_locale [String] the target locale code (e.g., 'es', 'fr', 'ja')
-    # @param source_locale [String, nil] the source locale code (optional, auto-detected if not provided)
+    # @param source_locale [String] the source locale code (e.g., 'en')
     # @param fast [Boolean, nil] enable fast mode for quicker results (optional)
     # @param reference [Hash, nil] additional context for translation (optional)
     # @param concurrent [Boolean] enable concurrent processing (default: false)
@@ -574,12 +579,12 @@ module LingoDotDev
     #     { title: 'Welcome', body: 'Hello there' },
     #     { title: 'About', body: 'Learn more' }
     #   ]
-    #   results = engine.batch_localize_objects(objects, target_locale: 'es')
+    #   results = engine.batch_localize_objects(objects, target_locale: 'es', source_locale: 'en')
     #   # => [
     #   #   { title: "Bienvenido", body: "Hola" },
     #   #   { title: "Acerca de", body: "Aprende más" }
     #   # ]
-    def batch_localize_objects(objects, target_locale:, source_locale: nil, fast: nil, reference: nil, concurrent: false)
+    def batch_localize_objects(objects, target_locale:, source_locale:, fast: nil, reference: nil, concurrent: false)
       raise ValidationError, 'Objects must be an Array' unless objects.is_a?(Array)
       raise ValidationError, 'Objects cannot be empty' if objects.empty?
       raise ValidationError, 'Target locale is required' if target_locale.nil? || target_locale.empty?
@@ -637,7 +642,7 @@ module LingoDotDev
 
       begin
         response = make_request(
-          "#{config.api_url}/recognize",
+          "#{config.api_url}/process/recognize",
           json: { text: text }
         )
 
@@ -658,7 +663,7 @@ module LingoDotDev
     #   # => { email: "user@example.com", id: "user-id" }
     def whoami
       begin
-        response = make_request("#{config.api_url}/whoami")
+        response = make_request("#{config.api_url}/users/me", method: :get)
 
         status_code = response.code.to_i
         return nil unless status_code >= 200 && status_code < 300
@@ -680,10 +685,11 @@ module LingoDotDev
     #
     # @param content [String, Hash] the content to translate (String for text, Hash for object)
     # @param api_key [String] your Lingo.dev API key
+    # @param engine_id [String] the engine ID for localization processing
     # @param target_locale [String] the target locale code (e.g., 'es', 'fr', 'ja')
-    # @param source_locale [String, nil] the source locale code (optional, auto-detected if not provided)
+    # @param source_locale [String] the source locale code (e.g., 'en')
     # @param fast [Boolean] enable fast mode for quicker results (default: true)
-    # @param api_url [String] the API endpoint URL (default: 'https://engine.lingo.dev')
+    # @param api_url [String] the API endpoint URL (default: 'https://api.lingo.dev')
     #
     # @return [String, Hash] localized content (String if input was String, Hash if input was Hash)
     #
@@ -691,18 +697,20 @@ module LingoDotDev
     # @raise [APIError] if the API request fails
     #
     # @example Translate text
-    #   result = LingoDotDev::Engine.quick_translate('Hello', api_key: 'your-api-key', target_locale: 'es')
+    #   result = LingoDotDev::Engine.quick_translate('Hello', api_key: 'your-api-key', engine_id: 'your-engine-id', target_locale: 'es', source_locale: 'en')
     #   # => "Hola"
     #
     # @example Translate object
     #   result = LingoDotDev::Engine.quick_translate(
     #     { greeting: 'Hello', farewell: 'Goodbye' },
     #     api_key: 'your-api-key',
-    #     target_locale: 'fr'
+    #     engine_id: 'your-engine-id',
+    #     target_locale: 'fr',
+    #     source_locale: 'en'
     #   )
     #   # => { greeting: "Bonjour", farewell: "Au revoir" }
-    def self.quick_translate(content, api_key:, target_locale:, source_locale: nil, fast: true, api_url: 'https://engine.lingo.dev')
-      engine = new(api_key: api_key, api_url: api_url)
+    def self.quick_translate(content, api_key:, engine_id:, target_locale:, source_locale:, fast: true, api_url: 'https://api.lingo.dev')
+      engine = new(api_key: api_key, engine_id: engine_id, api_url: api_url)
       case content
       when String
         engine.localize_text(
@@ -731,10 +739,11 @@ module LingoDotDev
     #
     # @param content [String, Hash] the content to translate (String for text, Hash for object)
     # @param api_key [String] your Lingo.dev API key
+    # @param engine_id [String] the engine ID for localization processing
     # @param target_locales [Array<String>] array of target locale codes
-    # @param source_locale [String, nil] the source locale code (optional, auto-detected if not provided)
+    # @param source_locale [String] the source locale code (e.g., 'en')
     # @param fast [Boolean] enable fast mode for quicker results (default: true)
-    # @param api_url [String] the API endpoint URL (default: 'https://engine.lingo.dev')
+    # @param api_url [String] the API endpoint URL (default: 'https://api.lingo.dev')
     #
     # @return [Array<String>, Array<Hash>] array of localized results (Strings if input was String, Hashes if input was Hash)
     #
@@ -745,7 +754,9 @@ module LingoDotDev
     #   results = LingoDotDev::Engine.quick_batch_translate(
     #     'Hello',
     #     api_key: 'your-api-key',
-    #     target_locales: ['es', 'fr', 'de']
+    #     engine_id: 'your-engine-id',
+    #     target_locales: ['es', 'fr', 'de'],
+    #     source_locale: 'en'
     #   )
     #   # => ["Hola", "Bonjour", "Hallo"]
     #
@@ -753,11 +764,13 @@ module LingoDotDev
     #   results = LingoDotDev::Engine.quick_batch_translate(
     #     { greeting: 'Hello' },
     #     api_key: 'your-api-key',
-    #     target_locales: ['es', 'fr']
+    #     engine_id: 'your-engine-id',
+    #     target_locales: ['es', 'fr'],
+    #     source_locale: 'en'
     #   )
     #   # => [{ greeting: "Hola" }, { greeting: "Bonjour" }]
-    def self.quick_batch_translate(content, api_key:, target_locales:, source_locale: nil, fast: true, api_url: 'https://engine.lingo.dev')
-      engine = new(api_key: api_key, api_url: api_url)
+    def self.quick_batch_translate(content, api_key:, engine_id:, target_locales:, source_locale:, fast: true, api_url: 'https://api.lingo.dev')
+      engine = new(api_key: api_key, engine_id: engine_id, api_url: api_url)
       case content
       when String
         engine.batch_localize_text(
@@ -784,24 +797,27 @@ module LingoDotDev
 
     private
 
-    def make_request(url, json: nil)
+    def make_request(url, json: nil, method: :post)
       uri = URI(url)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
       http.read_timeout = 60
       http.open_timeout = 60
 
-      request = Net::HTTP::Post.new(uri.path)
-      request['Authorization'] = "Bearer #{config.api_key}"
+      request = if method == :get
+        Net::HTTP::Get.new(uri.path)
+      else
+        Net::HTTP::Post.new(uri.path)
+      end
+      request['X-API-Key'] = config.api_key
       request['Content-Type'] = 'application/json; charset=utf-8'
       request.body = JSON.generate(json) if json
 
       http.request(request)
     end
 
-    def localize_raw(payload, target_locale:, source_locale: nil, fast: nil, reference: nil, concurrent: false, &progress_callback)
+    def localize_raw(payload, target_locale:, source_locale:, fast: nil, reference: nil, concurrent: false, &progress_callback)
       chunked_payload = extract_payload_chunks(payload)
-      workflow_id = SecureRandom.hex(8)
 
       processed_chunks = if concurrent && !progress_callback
         threads = chunked_payload.map do |chunk|
@@ -811,8 +827,7 @@ module LingoDotDev
               target_locale: target_locale,
               source_locale: source_locale,
               fast: fast,
-              reference: reference,
-              workflow_id: workflow_id
+              reference: reference
             )
           end
         end
@@ -826,8 +841,7 @@ module LingoDotDev
             target_locale: target_locale,
             source_locale: source_locale,
             fast: fast,
-            reference: reference,
-            workflow_id: workflow_id
+            reference: reference
           )
 
           progress_callback&.call(percentage_completed, chunk, processed_chunk)
@@ -841,17 +855,13 @@ module LingoDotDev
       result
     end
 
-    def localize_chunk(chunk, target_locale:, source_locale:, fast:, reference:, workflow_id:)
+    def localize_chunk(chunk, target_locale:, source_locale:, fast:, reference:)
       request_body = {
-        params: {
-          workflowId: workflow_id,
-          fast: fast || false
-        },
-        locale: {
-          source: source_locale,
-          target: target_locale
-        },
-        data: chunk
+        params: { fast: fast || false },
+        sourceLocale: source_locale,
+        targetLocale: target_locale,
+        data: chunk,
+        sessionId: @session_id
       }
 
       if reference && !reference.empty?
@@ -863,7 +873,7 @@ module LingoDotDev
 
       begin
         response = make_request(
-          "#{config.api_url}/i18n",
+          "#{config.api_url}/process/#{config.engine_id}/localize",
           json: request_body
         )
 
@@ -926,7 +936,7 @@ module LingoDotDev
       if status_code >= 500
         raise ServerError, "Server error (#{status_code}): #{response.message}. #{response.body}. This may be due to temporary service issues."
       elsif status_code == 400
-        raise ValidationError, "Invalid request (#{status_code}): #{response.message}"
+        raise ValidationError, "Invalid request (#{status_code}): #{response.message}. #{response.body}"
       elsif status_code == 401
         raise AuthenticationError, "Authentication failed (#{status_code}): #{response.message}"
       else

--- a/lib/lingodotdev.rb
+++ b/lib/lingodotdev.rb
@@ -817,6 +817,7 @@ module LingoDotDev
     end
 
     def localize_raw(payload, target_locale:, source_locale:, fast: nil, reference: nil, concurrent: false, &progress_callback)
+      raise ValidationError, 'Source locale is required' if source_locale.nil? || (source_locale.is_a?(String) && source_locale.empty?)
       chunked_payload = extract_payload_chunks(payload)
 
       processed_chunks = if concurrent && !progress_callback

--- a/lib/lingodotdev/version.rb
+++ b/lib/lingodotdev/version.rb
@@ -3,6 +3,6 @@
 # Ruby SDK for Lingo.dev localization and translation API.
 module LingoDotDev
   # Current version of the LingoDotDev SDK.
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end
 

--- a/spec/lingo_dot_dev/configuration_spec.rb
+++ b/spec/lingo_dot_dev/configuration_spec.rb
@@ -4,29 +4,31 @@ require 'spec_helper'
 
 RSpec.describe LingoDotDev::Configuration do
   describe 'initialization' do
-    it 'creates a configuration with valid api_key' do
-      config = described_class.new(api_key: 'test-key')
+    it 'creates a configuration with valid api_key and engine_id' do
+      config = described_class.new(api_key: 'test-key', engine_id: 'test-engine')
       expect(config.api_key).to eq('test-key')
+      expect(config.engine_id).to eq('test-engine')
     end
 
     it 'uses default api_url' do
-      config = described_class.new(api_key: 'test-key')
-      expect(config.api_url).to eq('https://engine.lingo.dev')
+      config = described_class.new(api_key: 'test-key', engine_id: 'test-engine')
+      expect(config.api_url).to eq('https://api.lingo.dev')
     end
 
     it 'uses default batch_size' do
-      config = described_class.new(api_key: 'test-key')
+      config = described_class.new(api_key: 'test-key', engine_id: 'test-engine')
       expect(config.batch_size).to eq(25)
     end
 
     it 'uses default ideal_batch_item_size' do
-      config = described_class.new(api_key: 'test-key')
+      config = described_class.new(api_key: 'test-key', engine_id: 'test-engine')
       expect(config.ideal_batch_item_size).to eq(250)
     end
 
     it 'allows customizing api_url' do
       config = described_class.new(
         api_key: 'test-key',
+        engine_id: 'test-engine',
         api_url: 'https://custom.example.com'
       )
       expect(config.api_url).to eq('https://custom.example.com')
@@ -35,6 +37,7 @@ RSpec.describe LingoDotDev::Configuration do
     it 'allows customizing batch_size' do
       config = described_class.new(
         api_key: 'test-key',
+        engine_id: 'test-engine',
         batch_size: 50
       )
       expect(config.batch_size).to eq(50)
@@ -43,6 +46,7 @@ RSpec.describe LingoDotDev::Configuration do
     it 'allows customizing ideal_batch_item_size' do
       config = described_class.new(
         api_key: 'test-key',
+        engine_id: 'test-engine',
         ideal_batch_item_size: 500
       )
       expect(config.ideal_batch_item_size).to eq(500)
@@ -52,20 +56,33 @@ RSpec.describe LingoDotDev::Configuration do
   describe 'validation' do
     it 'raises ValidationError when api_key is nil' do
       expect {
-        described_class.new(api_key: nil)
+        described_class.new(api_key: nil, engine_id: 'test-engine')
       }.to raise_error(LingoDotDev::ValidationError, /API key is required/)
     end
 
     it 'raises ValidationError when api_key is empty' do
       expect {
-        described_class.new(api_key: '')
+        described_class.new(api_key: '', engine_id: 'test-engine')
       }.to raise_error(LingoDotDev::ValidationError, /API key is required/)
+    end
+
+    it 'raises ValidationError when engine_id is nil' do
+      expect {
+        described_class.new(api_key: 'test-key', engine_id: nil)
+      }.to raise_error(LingoDotDev::ValidationError, /Engine ID is required/)
+    end
+
+    it 'raises ValidationError when engine_id is empty' do
+      expect {
+        described_class.new(api_key: 'test-key', engine_id: '')
+      }.to raise_error(LingoDotDev::ValidationError, /Engine ID is required/)
     end
 
     it 'raises ValidationError when api_url does not start with http/https' do
       expect {
         described_class.new(
           api_key: 'test-key',
+          engine_id: 'test-engine',
           api_url: 'ftp://example.com'
         )
       }.to raise_error(LingoDotDev::ValidationError, /valid HTTP\/HTTPS URL/)
@@ -75,6 +92,7 @@ RSpec.describe LingoDotDev::Configuration do
       expect {
         described_class.new(
           api_key: 'test-key',
+          engine_id: 'test-engine',
           batch_size: 0
         )
       }.to raise_error(LingoDotDev::ValidationError, /between 1 and 250/)
@@ -84,6 +102,7 @@ RSpec.describe LingoDotDev::Configuration do
       expect {
         described_class.new(
           api_key: 'test-key',
+          engine_id: 'test-engine',
           batch_size: 251
         )
       }.to raise_error(LingoDotDev::ValidationError, /between 1 and 250/)
@@ -93,6 +112,7 @@ RSpec.describe LingoDotDev::Configuration do
       expect {
         described_class.new(
           api_key: 'test-key',
+          engine_id: 'test-engine',
           ideal_batch_item_size: 0
         )
       }.to raise_error(LingoDotDev::ValidationError, /between 1 and 2500/)
@@ -102,6 +122,7 @@ RSpec.describe LingoDotDev::Configuration do
       expect {
         described_class.new(
           api_key: 'test-key',
+          engine_id: 'test-engine',
           ideal_batch_item_size: 2501
         )
       }.to raise_error(LingoDotDev::ValidationError, /between 1 and 2500/)
@@ -110,6 +131,7 @@ RSpec.describe LingoDotDev::Configuration do
     it 'accepts valid batch_size and ideal_batch_item_size values' do
       config = described_class.new(
         api_key: 'test-key',
+        engine_id: 'test-engine',
         batch_size: 100,
         ideal_batch_item_size: 1000
       )
@@ -120,25 +142,31 @@ RSpec.describe LingoDotDev::Configuration do
 
   describe 'attribute accessors' do
     it 'allows setting api_key after initialization' do
-      config = described_class.new(api_key: 'initial-key')
+      config = described_class.new(api_key: 'initial-key', engine_id: 'test-engine')
       config.api_key = 'new-key'
       expect(config.api_key).to eq('new-key')
     end
 
     it 'allows setting api_url after initialization' do
-      config = described_class.new(api_key: 'test-key')
+      config = described_class.new(api_key: 'test-key', engine_id: 'test-engine')
       config.api_url = 'https://new-url.com'
       expect(config.api_url).to eq('https://new-url.com')
     end
 
+    it 'allows setting engine_id after initialization' do
+      config = described_class.new(api_key: 'test-key', engine_id: 'test-engine')
+      config.engine_id = 'new-engine'
+      expect(config.engine_id).to eq('new-engine')
+    end
+
     it 'allows setting batch_size after initialization' do
-      config = described_class.new(api_key: 'test-key')
+      config = described_class.new(api_key: 'test-key', engine_id: 'test-engine')
       config.batch_size = 100
       expect(config.batch_size).to eq(100)
     end
 
     it 'allows setting ideal_batch_item_size after initialization' do
-      config = described_class.new(api_key: 'test-key')
+      config = described_class.new(api_key: 'test-key', engine_id: 'test-engine')
       config.ideal_batch_item_size = 1500
       expect(config.ideal_batch_item_size).to eq(1500)
     end

--- a/spec/lingo_dot_dev/configuration_spec.rb
+++ b/spec/lingo_dot_dev/configuration_spec.rb
@@ -4,31 +4,36 @@ require 'spec_helper'
 
 RSpec.describe LingoDotDev::Configuration do
   describe 'initialization' do
-    it 'creates a configuration with valid api_key and engine_id' do
+    it 'creates a configuration with valid api_key' do
+      config = described_class.new(api_key: 'test-key')
+      expect(config.api_key).to eq('test-key')
+      expect(config.engine_id).to be_nil
+    end
+
+    it 'creates a configuration with api_key and engine_id' do
       config = described_class.new(api_key: 'test-key', engine_id: 'test-engine')
       expect(config.api_key).to eq('test-key')
       expect(config.engine_id).to eq('test-engine')
     end
 
     it 'uses default api_url' do
-      config = described_class.new(api_key: 'test-key', engine_id: 'test-engine')
+      config = described_class.new(api_key: 'test-key')
       expect(config.api_url).to eq('https://api.lingo.dev')
     end
 
     it 'uses default batch_size' do
-      config = described_class.new(api_key: 'test-key', engine_id: 'test-engine')
+      config = described_class.new(api_key: 'test-key')
       expect(config.batch_size).to eq(25)
     end
 
     it 'uses default ideal_batch_item_size' do
-      config = described_class.new(api_key: 'test-key', engine_id: 'test-engine')
+      config = described_class.new(api_key: 'test-key')
       expect(config.ideal_batch_item_size).to eq(250)
     end
 
     it 'allows customizing api_url' do
       config = described_class.new(
         api_key: 'test-key',
-        engine_id: 'test-engine',
         api_url: 'https://custom.example.com'
       )
       expect(config.api_url).to eq('https://custom.example.com')
@@ -37,7 +42,6 @@ RSpec.describe LingoDotDev::Configuration do
     it 'allows customizing batch_size' do
       config = described_class.new(
         api_key: 'test-key',
-        engine_id: 'test-engine',
         batch_size: 50
       )
       expect(config.batch_size).to eq(50)
@@ -46,7 +50,6 @@ RSpec.describe LingoDotDev::Configuration do
     it 'allows customizing ideal_batch_item_size' do
       config = described_class.new(
         api_key: 'test-key',
-        engine_id: 'test-engine',
         ideal_batch_item_size: 500
       )
       expect(config.ideal_batch_item_size).to eq(500)
@@ -56,33 +59,20 @@ RSpec.describe LingoDotDev::Configuration do
   describe 'validation' do
     it 'raises ValidationError when api_key is nil' do
       expect {
-        described_class.new(api_key: nil, engine_id: 'test-engine')
+        described_class.new(api_key: nil)
       }.to raise_error(LingoDotDev::ValidationError, /API key is required/)
     end
 
     it 'raises ValidationError when api_key is empty' do
       expect {
-        described_class.new(api_key: '', engine_id: 'test-engine')
+        described_class.new(api_key: '')
       }.to raise_error(LingoDotDev::ValidationError, /API key is required/)
-    end
-
-    it 'raises ValidationError when engine_id is nil' do
-      expect {
-        described_class.new(api_key: 'test-key', engine_id: nil)
-      }.to raise_error(LingoDotDev::ValidationError, /Engine ID is required/)
-    end
-
-    it 'raises ValidationError when engine_id is empty' do
-      expect {
-        described_class.new(api_key: 'test-key', engine_id: '')
-      }.to raise_error(LingoDotDev::ValidationError, /Engine ID is required/)
     end
 
     it 'raises ValidationError when api_url does not start with http/https' do
       expect {
         described_class.new(
           api_key: 'test-key',
-          engine_id: 'test-engine',
           api_url: 'ftp://example.com'
         )
       }.to raise_error(LingoDotDev::ValidationError, /valid HTTP\/HTTPS URL/)
@@ -92,7 +82,6 @@ RSpec.describe LingoDotDev::Configuration do
       expect {
         described_class.new(
           api_key: 'test-key',
-          engine_id: 'test-engine',
           batch_size: 0
         )
       }.to raise_error(LingoDotDev::ValidationError, /between 1 and 250/)
@@ -102,7 +91,6 @@ RSpec.describe LingoDotDev::Configuration do
       expect {
         described_class.new(
           api_key: 'test-key',
-          engine_id: 'test-engine',
           batch_size: 251
         )
       }.to raise_error(LingoDotDev::ValidationError, /between 1 and 250/)
@@ -112,7 +100,6 @@ RSpec.describe LingoDotDev::Configuration do
       expect {
         described_class.new(
           api_key: 'test-key',
-          engine_id: 'test-engine',
           ideal_batch_item_size: 0
         )
       }.to raise_error(LingoDotDev::ValidationError, /between 1 and 2500/)
@@ -122,7 +109,6 @@ RSpec.describe LingoDotDev::Configuration do
       expect {
         described_class.new(
           api_key: 'test-key',
-          engine_id: 'test-engine',
           ideal_batch_item_size: 2501
         )
       }.to raise_error(LingoDotDev::ValidationError, /between 1 and 2500/)
@@ -131,7 +117,6 @@ RSpec.describe LingoDotDev::Configuration do
     it 'accepts valid batch_size and ideal_batch_item_size values' do
       config = described_class.new(
         api_key: 'test-key',
-        engine_id: 'test-engine',
         batch_size: 100,
         ideal_batch_item_size: 1000
       )
@@ -142,31 +127,31 @@ RSpec.describe LingoDotDev::Configuration do
 
   describe 'attribute accessors' do
     it 'allows setting api_key after initialization' do
-      config = described_class.new(api_key: 'initial-key', engine_id: 'test-engine')
+      config = described_class.new(api_key: 'initial-key')
       config.api_key = 'new-key'
       expect(config.api_key).to eq('new-key')
     end
 
     it 'allows setting api_url after initialization' do
-      config = described_class.new(api_key: 'test-key', engine_id: 'test-engine')
+      config = described_class.new(api_key: 'test-key')
       config.api_url = 'https://new-url.com'
       expect(config.api_url).to eq('https://new-url.com')
     end
 
     it 'allows setting engine_id after initialization' do
-      config = described_class.new(api_key: 'test-key', engine_id: 'test-engine')
+      config = described_class.new(api_key: 'test-key')
       config.engine_id = 'new-engine'
       expect(config.engine_id).to eq('new-engine')
     end
 
     it 'allows setting batch_size after initialization' do
-      config = described_class.new(api_key: 'test-key', engine_id: 'test-engine')
+      config = described_class.new(api_key: 'test-key')
       config.batch_size = 100
       expect(config.batch_size).to eq(100)
     end
 
     it 'allows setting ideal_batch_item_size after initialization' do
-      config = described_class.new(api_key: 'test-key', engine_id: 'test-engine')
+      config = described_class.new(api_key: 'test-key')
       config.ideal_batch_item_size = 1500
       expect(config.ideal_batch_item_size).to eq(1500)
     end

--- a/spec/lingo_dot_dev/engine_spec.rb
+++ b/spec/lingo_dot_dev/engine_spec.rb
@@ -4,19 +4,22 @@ require 'spec_helper'
 
 RSpec.describe LingoDotDev::Engine do
   let(:api_key) { ENV['LINGODOTDEV_API_KEY'] }
-  let(:api_url) { 'https://engine.lingo.dev' }
+  let(:engine_id) { ENV['LINGODOTDEV_ENGINE_ID'] }
+  let(:api_url) { 'https://api.lingo.dev' }
   let(:target_locale) { 'es' }
   let(:source_locale) { 'en' }
 
   describe 'initialization' do
-    it 'creates an engine with valid api_key' do
-      engine = described_class.new(api_key: api_key)
+    it 'creates an engine with valid api_key and engine_id' do
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       expect(engine.config.api_key).to eq(api_key)
+      expect(engine.config.engine_id).to eq(engine_id)
     end
 
     it 'creates engine with custom configuration' do
       engine = described_class.new(
         api_key: api_key,
+        engine_id: engine_id,
         api_url: 'https://custom.example.com',
         batch_size: 50,
         ideal_batch_item_size: 500
@@ -27,7 +30,7 @@ RSpec.describe LingoDotDev::Engine do
     end
 
     it 'allows block-based configuration' do
-      engine = described_class.new(api_key: api_key) do |config|
+      engine = described_class.new(api_key: api_key, engine_id: engine_id) do |config|
         config.batch_size = 75
       end
       expect(engine.config.batch_size).to eq(75)
@@ -36,17 +39,7 @@ RSpec.describe LingoDotDev::Engine do
 
   describe '#localize_text' do
     it 'localizes text to target locale' do
-      engine = described_class.new(api_key: api_key)
-      result = engine.localize_text(
-        'Hello world',
-        target_locale: target_locale
-      )
-      expect(result).to be_a(String)
-      expect(result.length).to be > 0
-    end
-
-    it 'localizes text with source locale specified' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       result = engine.localize_text(
         'Hello world',
         target_locale: target_locale,
@@ -57,10 +50,11 @@ RSpec.describe LingoDotDev::Engine do
     end
 
     it 'localizes text with fast flag' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       result = engine.localize_text(
         'Hello world',
         target_locale: target_locale,
+        source_locale: source_locale,
         fast: true
       )
       expect(result).to be_a(String)
@@ -68,11 +62,12 @@ RSpec.describe LingoDotDev::Engine do
     end
 
     it 'localizes text with reference context' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       reference = { context: 'greeting' }
       result = engine.localize_text(
         'Hello',
         target_locale: target_locale,
+        source_locale: source_locale,
         reference: reference
       )
       expect(result).to be_a(String)
@@ -80,201 +75,189 @@ RSpec.describe LingoDotDev::Engine do
     end
 
     it 'supports progress callback block' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       progress_updates = []
       result = engine.localize_text(
         'Hello world',
-        target_locale: target_locale
+        target_locale: target_locale,
+        source_locale: source_locale
       ) { |progress| progress_updates << progress }
       expect(result).to be_a(String)
       expect(progress_updates).not_to be_empty if result.length > 0
     end
 
     it 'supports on_progress callback parameter' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       progress_updates = []
       result = engine.localize_text(
         'Hello world',
         target_locale: target_locale,
+        source_locale: source_locale,
         on_progress: proc { |progress| progress_updates << progress }
       )
       expect(result).to be_a(String)
     end
 
     it 'raises ValidationError when target_locale is nil' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       expect {
-        engine.localize_text('Hello', target_locale: nil)
+        engine.localize_text('Hello', target_locale: nil, source_locale: source_locale)
       }.to raise_error(LingoDotDev::ValidationError, /Target locale is required/)
     end
 
     it 'raises ValidationError when target_locale is empty' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       expect {
-        engine.localize_text('Hello', target_locale: '')
+        engine.localize_text('Hello', target_locale: '', source_locale: source_locale)
       }.to raise_error(LingoDotDev::ValidationError, /Target locale is required/)
     end
 
     it 'raises ValidationError when text is nil' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       expect {
-        engine.localize_text(nil, target_locale: target_locale)
+        engine.localize_text(nil, target_locale: target_locale, source_locale: source_locale)
       }.to raise_error(LingoDotDev::ValidationError, /Text cannot be nil/)
     end
   end
 
   describe '#localize_object' do
     it 'localizes a hash object to target locale' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       obj = { greeting: 'Hello', farewell: 'Goodbye' }
-      result = engine.localize_object(
-        obj,
-        target_locale: target_locale
-      )
-      expect(result).to be_a(Hash)
-      expect(result.keys).to include('greeting', 'farewell')
-    end
-
-    it 'localizes object with source locale' do
-      engine = described_class.new(api_key: api_key)
-      obj = { message: 'Hello world' }
       result = engine.localize_object(
         obj,
         target_locale: target_locale,
         source_locale: source_locale
       )
       expect(result).to be_a(Hash)
+      expect(result.keys).to include('greeting', 'farewell')
     end
 
     it 'localizes object with fast flag' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       obj = { greeting: 'Hi' }
       result = engine.localize_object(
         obj,
         target_locale: target_locale,
+        source_locale: source_locale,
         fast: true
       )
       expect(result).to be_a(Hash)
     end
 
     it 'supports progress callback for objects' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       obj = { text: 'Hello' }
       progress_updates = []
       result = engine.localize_object(
         obj,
-        target_locale: target_locale
+        target_locale: target_locale,
+        source_locale: source_locale
       ) { |progress| progress_updates << progress }
       expect(result).to be_a(Hash)
     end
 
     it 'raises ValidationError when target_locale is nil' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       expect {
-        engine.localize_object({ text: 'Hello' }, target_locale: nil)
+        engine.localize_object({ text: 'Hello' }, target_locale: nil, source_locale: source_locale)
       }.to raise_error(LingoDotDev::ValidationError, /Target locale is required/)
     end
 
     it 'raises ValidationError when object is nil' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       expect {
-        engine.localize_object(nil, target_locale: target_locale)
+        engine.localize_object(nil, target_locale: target_locale, source_locale: source_locale)
       }.to raise_error(LingoDotDev::ValidationError, /Object cannot be nil/)
     end
 
     it 'raises ValidationError when object is not a Hash' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       expect {
-        engine.localize_object('not a hash', target_locale: target_locale)
+        engine.localize_object('not a hash', target_locale: target_locale, source_locale: source_locale)
       }.to raise_error(LingoDotDev::ValidationError, /Object must be a Hash/)
     end
   end
 
   describe '#localize_chat' do
     it 'localizes chat messages to target locale' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       chat = [
         { name: 'user', text: 'Hello!' },
         { name: 'assistant', text: 'Hi there!' }
       ]
       result = engine.localize_chat(
         chat,
-        target_locale: target_locale
+        target_locale: target_locale,
+        source_locale: source_locale
       )
       expect(result).to be_an(Array)
       expect(result.length).to eq(2)
     end
 
-    it 'localizes chat with source locale' do
-      engine = described_class.new(api_key: api_key)
-      chat = [{ name: 'user', text: 'Hello' }]
-      result = engine.localize_chat(
-        chat,
-        target_locale: target_locale,
-        source_locale: source_locale
-      )
-      expect(result).to be_an(Array)
-    end
-
     it 'localizes chat with fast flag' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       chat = [{ name: 'user', text: 'Hi' }]
       result = engine.localize_chat(
         chat,
         target_locale: target_locale,
+        source_locale: source_locale,
         fast: true
       )
       expect(result).to be_an(Array)
     end
 
     it 'supports progress callback for chat' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       chat = [{ name: 'user', text: 'Hello' }]
       progress_updates = []
       result = engine.localize_chat(
         chat,
-        target_locale: target_locale
+        target_locale: target_locale,
+        source_locale: source_locale
       ) { |progress| progress_updates << progress }
       expect(result).to be_an(Array)
     end
 
     it 'raises ValidationError when target_locale is nil' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       expect {
-        engine.localize_chat([], target_locale: nil)
+        engine.localize_chat([], target_locale: nil, source_locale: source_locale)
       }.to raise_error(LingoDotDev::ValidationError, /Target locale is required/)
     end
 
     it 'raises ValidationError when chat is nil' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       expect {
-        engine.localize_chat(nil, target_locale: target_locale)
+        engine.localize_chat(nil, target_locale: target_locale, source_locale: source_locale)
       }.to raise_error(LingoDotDev::ValidationError, /Chat cannot be nil/)
     end
 
     it 'raises ValidationError when chat is not an Array' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       expect {
-        engine.localize_chat({}, target_locale: target_locale)
+        engine.localize_chat({}, target_locale: target_locale, source_locale: source_locale)
       }.to raise_error(LingoDotDev::ValidationError, /Chat must be an Array/)
     end
 
     it 'raises ValidationError when chat messages lack name' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       expect {
         engine.localize_chat(
           [{ text: 'Hello' }],
-          target_locale: target_locale
+          target_locale: target_locale,
+          source_locale: source_locale
         )
       }.to raise_error(LingoDotDev::ValidationError, /:name and :text keys/)
     end
 
     it 'raises ValidationError when chat messages lack text' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       expect {
         engine.localize_chat(
           [{ name: 'user' }],
-          target_locale: target_locale
+          target_locale: target_locale,
+          source_locale: source_locale
         )
       }.to raise_error(LingoDotDev::ValidationError, /:name and :text keys/)
     end
@@ -309,7 +292,7 @@ RSpec.describe LingoDotDev::Engine do
         </html>
       HTML
 
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       extracted_content = nil
       call_params = nil
 
@@ -357,7 +340,7 @@ RSpec.describe LingoDotDev::Engine do
 
     it 'localizes HTML with source locale' do
       html = '<html><head><title>Hello</title></head><body><p>World</p></body></html>'
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       call_params = nil
       allow(engine).to receive(:localize_raw) do |content, params, &block|
         call_params = params
@@ -373,82 +356,73 @@ RSpec.describe LingoDotDev::Engine do
 
     it 'localizes HTML with fast flag' do
       html = '<html><head><title>Hello</title></head><body><p>World</p></body></html>'
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       call_params = nil
       allow(engine).to receive(:localize_raw) do |content, params, &block|
         call_params = params
         { 'head/0/0' => 'Hola', 'body/0/0' => 'Mundo' }
       end
 
-      result = engine.localize_html(html, target_locale: 'es', fast: true)
+      result = engine.localize_html(html, target_locale: 'es', source_locale: 'en', fast: true)
 
       expect(call_params[:fast]).to eq(true)
     end
 
     it 'supports progress callback for HTML' do
       html = '<html><head><title>Hello</title></head><body><p>World</p></body></html>'
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       progress_updates = []
       allow(engine).to receive(:localize_raw) do |content, params, &block|
         block&.call(100, {}, {})
         { 'head/0/0' => 'Hola', 'body/0/0' => 'Mundo' }
       end
 
-      result = engine.localize_html(html, target_locale: 'es') { |progress| progress_updates << progress }
+      result = engine.localize_html(html, target_locale: 'es', source_locale: 'en') { |progress| progress_updates << progress }
 
       expect(progress_updates).not_to be_empty
     end
 
     it 'raises ValidationError when target_locale is nil' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       expect {
-        engine.localize_html('<html></html>', target_locale: nil)
+        engine.localize_html('<html></html>', target_locale: nil, source_locale: source_locale)
       }.to raise_error(LingoDotDev::ValidationError, /Target locale is required/)
     end
 
     it 'raises ValidationError when target_locale is empty' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       expect {
-        engine.localize_html('<html></html>', target_locale: '')
+        engine.localize_html('<html></html>', target_locale: '', source_locale: source_locale)
       }.to raise_error(LingoDotDev::ValidationError, /Target locale is required/)
     end
 
     it 'raises ValidationError when html is nil' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       expect {
-        engine.localize_html(nil, target_locale: 'es')
+        engine.localize_html(nil, target_locale: 'es', source_locale: source_locale)
       }.to raise_error(LingoDotDev::ValidationError, /HTML cannot be nil/)
     end
   end
 
   describe '#batch_localize_text' do
     it 'batch localizes text to multiple locales' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       results = engine.batch_localize_text(
         'Hello world',
-        target_locales: ['es', 'fr']
+        target_locales: ['es', 'fr'],
+        source_locale: source_locale
       )
       expect(results).to be_an(Array)
       expect(results.length).to eq(2)
       expect(results.all? { |r| r.is_a?(String) }).to be true
     end
 
-    it 'batch localizes with source locale' do
-      engine = described_class.new(api_key: api_key)
-      results = engine.batch_localize_text(
-        'Hello',
-        target_locales: ['es', 'de'],
-        source_locale: source_locale
-      )
-      expect(results).to be_an(Array)
-      expect(results.length).to eq(2)
-    end
-
     it 'batch localizes with fast flag' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       results = engine.batch_localize_text(
         'Hi',
         target_locales: ['es', 'fr'],
+        source_locale: source_locale,
         fast: true
       )
       expect(results).to be_an(Array)
@@ -456,10 +430,11 @@ RSpec.describe LingoDotDev::Engine do
     end
 
     it 'batch localizes concurrently' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       results = engine.batch_localize_text(
         'Hello world',
         target_locales: ['es', 'fr', 'de'],
+        source_locale: source_locale,
         concurrent: true
       )
       expect(results).to be_an(Array)
@@ -467,67 +442,58 @@ RSpec.describe LingoDotDev::Engine do
     end
 
     it 'raises ValidationError when text is nil' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       expect {
-        engine.batch_localize_text(nil, target_locales: ['es'])
+        engine.batch_localize_text(nil, target_locales: ['es'], source_locale: source_locale)
       }.to raise_error(LingoDotDev::ValidationError, /Text cannot be nil/)
     end
 
     it 'raises ValidationError when target_locales is not an Array' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       expect {
-        engine.batch_localize_text('Hello', target_locales: 'es')
+        engine.batch_localize_text('Hello', target_locales: 'es', source_locale: source_locale)
       }.to raise_error(LingoDotDev::ValidationError, /Target locales must be an Array/)
     end
 
     it 'raises ValidationError when target_locales is empty' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       expect {
-        engine.batch_localize_text('Hello', target_locales: [])
+        engine.batch_localize_text('Hello', target_locales: [], source_locale: source_locale)
       }.to raise_error(LingoDotDev::ValidationError, /Target locales cannot be empty/)
     end
   end
 
   describe '#batch_localize_objects' do
     it 'batch localizes multiple objects to same locale' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       objects = [
         { greeting: 'Hello' },
         { farewell: 'Goodbye' }
       ]
       results = engine.batch_localize_objects(
         objects,
-        target_locale: target_locale
+        target_locale: target_locale,
+        source_locale: source_locale
       )
       expect(results).to be_an(Array)
       expect(results.length).to eq(2)
       expect(results.all? { |r| r.is_a?(Hash) }).to be true
     end
 
-    it 'batch localizes objects with source locale' do
-      engine = described_class.new(api_key: api_key)
-      objects = [{ text: 'Hello' }]
-      results = engine.batch_localize_objects(
-        objects,
-        target_locale: target_locale,
-        source_locale: source_locale
-      )
-      expect(results).to be_an(Array)
-    end
-
     it 'batch localizes objects with fast flag' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       objects = [{ text: 'Hi' }]
       results = engine.batch_localize_objects(
         objects,
         target_locale: target_locale,
+        source_locale: source_locale,
         fast: true
       )
       expect(results).to be_an(Array)
     end
 
     it 'batch localizes objects concurrently' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       objects = [
         { text: 'Hello' },
         { text: 'Hi' },
@@ -536,6 +502,7 @@ RSpec.describe LingoDotDev::Engine do
       results = engine.batch_localize_objects(
         objects,
         target_locale: target_locale,
+        source_locale: source_locale,
         concurrent: true
       )
       expect(results).to be_an(Array)
@@ -543,38 +510,41 @@ RSpec.describe LingoDotDev::Engine do
     end
 
     it 'raises ValidationError when objects is not an Array' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       expect {
         engine.batch_localize_objects(
           { text: 'Hello' },
-          target_locale: target_locale
+          target_locale: target_locale,
+          source_locale: source_locale
         )
       }.to raise_error(LingoDotDev::ValidationError, /Objects must be an Array/)
     end
 
     it 'raises ValidationError when objects is empty' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       expect {
-        engine.batch_localize_objects([], target_locale: target_locale)
+        engine.batch_localize_objects([], target_locale: target_locale, source_locale: source_locale)
       }.to raise_error(LingoDotDev::ValidationError, /Objects cannot be empty/)
     end
 
     it 'raises ValidationError when target_locale is nil' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       expect {
         engine.batch_localize_objects(
           [{ text: 'Hello' }],
-          target_locale: nil
+          target_locale: nil,
+          source_locale: source_locale
         )
       }.to raise_error(LingoDotDev::ValidationError, /Target locale is required/)
     end
 
     it 'raises ValidationError when object is not a Hash' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       expect {
         engine.batch_localize_objects(
           ['not a hash'],
-          target_locale: target_locale
+          target_locale: target_locale,
+          source_locale: source_locale
         )
       }.to raise_error(LingoDotDev::ValidationError, /Each object must be a Hash/)
     end
@@ -582,28 +552,28 @@ RSpec.describe LingoDotDev::Engine do
 
   describe '#recognize_locale' do
     it 'recognizes locale of given text' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       locale = engine.recognize_locale('Hello world')
       expect(locale).to be_a(String)
       expect(locale.length).to be > 0
     end
 
     it 'raises ValidationError when text is nil' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       expect {
         engine.recognize_locale(nil)
       }.to raise_error(LingoDotDev::ValidationError, /Text cannot be empty/)
     end
 
     it 'raises ValidationError when text is empty' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       expect {
         engine.recognize_locale('')
       }.to raise_error(LingoDotDev::ValidationError, /Text cannot be empty/)
     end
 
     it 'raises ValidationError when text is only whitespace' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       expect {
         engine.recognize_locale('   ')
       }.to raise_error(LingoDotDev::ValidationError, /Text cannot be empty/)
@@ -612,7 +582,7 @@ RSpec.describe LingoDotDev::Engine do
 
   describe '#whoami' do
     it 'returns user information' do
-      engine = described_class.new(api_key: api_key)
+      engine = described_class.new(api_key: api_key, engine_id: engine_id)
       result = engine.whoami
       if result
         expect(result).to be_a(Hash)
@@ -626,7 +596,9 @@ RSpec.describe LingoDotDev::Engine do
       result = described_class.quick_translate(
         'Hello world',
         api_key: api_key,
-        target_locale: target_locale
+        engine_id: engine_id,
+        target_locale: target_locale,
+        source_locale: source_locale
       )
       expect(result).to be_a(String)
       expect(result.length).to be > 0
@@ -636,7 +608,9 @@ RSpec.describe LingoDotDev::Engine do
       result = described_class.quick_translate(
         { greeting: 'Hello', farewell: 'Goodbye' },
         api_key: api_key,
-        target_locale: target_locale
+        engine_id: engine_id,
+        target_locale: target_locale,
+        source_locale: source_locale
       )
       expect(result).to be_a(Hash)
     end
@@ -646,7 +620,9 @@ RSpec.describe LingoDotDev::Engine do
         described_class.quick_translate(
           123,
           api_key: api_key,
-          target_locale: target_locale
+          engine_id: engine_id,
+          target_locale: target_locale,
+          source_locale: source_locale
         )
       }.to raise_error(LingoDotDev::ValidationError, /Content must be a String or Hash/)
     end
@@ -657,7 +633,9 @@ RSpec.describe LingoDotDev::Engine do
       results = described_class.quick_batch_translate(
         'Hello',
         api_key: api_key,
-        target_locales: ['es', 'fr']
+        engine_id: engine_id,
+        target_locales: ['es', 'fr'],
+        source_locale: source_locale
       )
       expect(results).to be_an(Array)
       expect(results.length).to eq(2)
@@ -668,7 +646,9 @@ RSpec.describe LingoDotDev::Engine do
       results = described_class.quick_batch_translate(
         { greeting: 'Hello' },
         api_key: api_key,
-        target_locales: ['es', 'fr']
+        engine_id: engine_id,
+        target_locales: ['es', 'fr'],
+        source_locale: source_locale
       )
       expect(results).to be_an(Array)
       expect(results.length).to eq(2)
@@ -680,7 +660,9 @@ RSpec.describe LingoDotDev::Engine do
         described_class.quick_batch_translate(
           123,
           api_key: api_key,
-          target_locales: ['es']
+          engine_id: engine_id,
+          target_locales: ['es'],
+          source_locale: source_locale
         )
       }.to raise_error(LingoDotDev::ValidationError, /Content must be a String or Hash/)
     end

--- a/spec/lingo_dot_dev/engine_spec.rb
+++ b/spec/lingo_dot_dev/engine_spec.rb
@@ -16,6 +16,12 @@ RSpec.describe LingoDotDev::Engine do
       expect(engine.config.engine_id).to eq(engine_id)
     end
 
+    it 'creates an engine without engine_id' do
+      engine = described_class.new(api_key: api_key)
+      expect(engine.config.api_key).to eq(api_key)
+      expect(engine.config.engine_id).to be_nil
+    end
+
     it 'creates engine with custom configuration' do
       engine = described_class.new(
         api_key: api_key,


### PR DESCRIPTION
 ## Summary                                                                                                         
  - Migrate from legacy API (engine.lingo.dev) to vNext API (api.lingo.dev)
  - Replace Authorization: Bearer with X-API-Key header                                                              
  - New endpoints: /process/localize, /process/recognize, GET /users/me                                            
  - engine_id is now optional (passed as engineId in request body when provided)
  - Add required source_locale parameter to all localization methods
  - Generate per-instance session_id (replaces per-request workflow_id)
  - Restructure request body: flat sourceLocale/targetLocale instead of nested locale object
  - Bump version to 0.2.0

  ## Breaking changes
  - Default api_url changed from https://engine.lingo.dev to https://api.lingo.dev
  - source_locale is now required on all localization methods (was optional)
  - engine_id is now optional (was required) — passed in request body instead of URL path

  ## Test plan

  - [x] All specs pass
  - [x] Live tested all methods: whoami, recognize_locale, localize_text, localize_object, localize_chat, localize_html, batch_localize_text, batch_localize_objects, quick_translate, quick_batch_translate
  - [x] Verified engine works with and without engine_id
  - [x] No remaining legacy references

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Engine initialization now requires engine_id parameter in addition to api_key
  * All localization methods (text, object, chat, HTML, batch operations) now require explicit source_locale parameter (previously optional)
  * API endpoint URL changed to api.lingo.dev
  * HTTP authentication header updated to X-API-Key

* **Documentation**
  * Updated all README examples and documentation to reflect new API requirements

* **Updates**
  * Version bumped to 0.2.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->